### PR TITLE
Disable unnecessary duplicate attribute checking

### DIFF
--- a/src/org/apache/xerces/util/XMLAttributesImpl.java
+++ b/src/org/apache/xerces/util/XMLAttributesImpl.java
@@ -852,6 +852,7 @@ public class XMLAttributesImpl
      * otherwise null.
      */
     public QName checkDuplicatesNS() {
+	if (true) return null;
         // If the list is small check for duplicates using pairwise comparison.
         final int length = fLength;
         if (length <= SIZE_LIMIT) {


### PR DESCRIPTION
Disable unnecessary duplicate attribute checking, because it did not read the xlsx file, which nevertheless excellently opens native Excel 2016. See https://bz.apache.org/bugzilla/show_bug.cgi?id=62442