### PR TITLE
XERCESJ-1707: Unable to build xercesImpl.jar with Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Java template
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+build/
+*.iml

--- a/build.xml
+++ b/build.xml
@@ -286,7 +286,7 @@ Authors:
       </fileset>
     </copy>
 
-    <xjavac srcdir="${build.src}"
+    <javac srcdir="${build.src}"
            destdir="${build.dest}"
            source="${javac.source}"
            target="${javac.target}"

--- a/src/org/apache/html/dom/HTMLElementImpl.java
+++ b/src/org/apache/html/dom/HTMLElementImpl.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 
 import org.apache.xerces.dom.ElementImpl;
 import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.html.HTMLElement;
@@ -58,7 +59,11 @@ public class HTMLElementImpl
     public HTMLElementImpl( HTMLDocumentImpl owner, String tagName ) {
         super( owner, tagName.toUpperCase(Locale.ENGLISH) );
     }
-    
+
+    public Document getContentDocument() {
+        return ownerDocument.getOwnerDocument();
+    }
+
     public String getId() {
         return getAttribute( "id" );
     }

--- a/src/org/apache/html/dom/HTMLIFrameElementImpl.java
+++ b/src/org/apache/html/dom/HTMLIFrameElementImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.html.dom;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.html.HTMLIFrameElement;
 
 /**

--- a/src/org/apache/html/dom/HTMLObjectElementImpl.java
+++ b/src/org/apache/html/dom/HTMLObjectElementImpl.java
@@ -16,6 +16,7 @@
  */
 package org.apache.html.dom;
 
+import org.w3c.dom.Document;
 import org.w3c.dom.html.HTMLObjectElement;
 
 /**


### PR DESCRIPTION
see https://issues.apache.org/jira/projects/XERCESJ/issues/XERCESJ-1707

This PR fixes the problem, try 

```
> ant -v -d -Dant.java.version=1.8 clean jar
```

with a Java 11 JDK.