### PR TITLE
Change the method name "getIndenting" to "isIndent"

### DIFF
--- a/src/org/apache/xml/serialize/BaseMarkupSerializer.java
+++ b/src/org/apache/xml/serialize/BaseMarkupSerializer.java
@@ -355,7 +355,7 @@ public abstract class BaseMarkupSerializer
             _writer = _encodingInfo.getWriter(_output);
         }
 
-        if ( _format.getIndenting() ) {
+        if ( _format.isIndent() ) {
             _indenting = true;
             _printer = new IndentPrinter( _writer, _format );
         } else {

--- a/src/org/apache/xml/serialize/IndentPrinter.java
+++ b/src/org/apache/xml/serialize/IndentPrinter.java
@@ -272,7 +272,7 @@ public class IndentPrinter
         if ( _line.length() > 0 ) {
             try {
                 
-                if ( _format.getIndenting() && ! preserveSpace ) {
+                if ( _format.isIndent() && ! preserveSpace ) {
                     // Make sure the indentation does not blow us away.
                     indent = _thisIndent;
                     if ( ( 2 * indent ) > _format.getLineWidth() && _format.getLineWidth() > 0 )

--- a/src/org/apache/xml/serialize/OutputFormat.java
+++ b/src/org/apache/xml/serialize/OutputFormat.java
@@ -385,7 +385,7 @@ public class OutputFormat
     /**
      * Returns true if indentation was specified.
      */
-    public boolean getIndenting()
+    public boolean isIndent()
     {
         return ( _indent > 0 );
     }


### PR DESCRIPTION
First, this method returns a boolean value by checking whether the indentation is specified or not. It would be better to name it "is XXX" to follow the Java naming convention.
Second, above the method, there is another method named "getIndent". Hence, to keep consistent with this method, it would be better to name this one "isIndent".