### PR TITLE
[FIX] XSComplexTypeDecl::setValues must set name field

### DIFF
--- a/src/org/apache/xerces/impl/xs/XSComplexTypeDecl.java
+++ b/src/org/apache/xerces/impl/xs/XSComplexTypeDecl.java
@@ -109,6 +109,7 @@ public class XSComplexTypeDecl implements XSComplexTypeDefinition, TypeInfo {
             boolean isAbstract, XSAttributeGroupDecl attrGrp, 
             XSSimpleType simpleType, XSParticleDecl particle,
             XSObjectListImpl annotations) {
+        fName = name;
         fTargetNamespace = targetNamespace;
         fBaseType = baseType;
         fDerivedBy = derivedBy;


### PR DESCRIPTION
XSComplexTypeDecl::setValues does currently not update the "fName" field